### PR TITLE
Pinning HuggingFace and Transformers versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,11 @@ torch<2.1
 torchvision
 torchaudio
 accelerate==0.22 
-transformers>=4.42.0
+transformers==4.44.2
 diffusers==0.20.0 
 Pillow>=10.0.0
 perceiver-io[vision]
 packaging>24.0
 cchardet==2.2.0a2
 supervision
+huggingface-hub==0.24.5


### PR DESCRIPTION
*Issue #, if available:*
None.

*Description of changes:*
Original error with main branch at commit fdba10ba4ec7594bb8685c8cd14e76a46a36aa8d :

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
pathos 0.3.3 requires dill>=0.3.9, but you have dill 0.3.8 which is incompatible.
pathos 0.3.3 requires multiprocess>=0.70.17, but you have multiprocess 0.70.16 which is incompatible.
```
and 

``` ImportError: cannot import name 'cached_download' from 'huggingface_hub' (/home/ec2-user/anaconda3/envs/pytorch_p310/lib/python3.10/site-packages/huggingface_hub/__init__.py) ```

Resolution:
Pinning HuggingFace == 0.24.5 and Transformers==4.44.2 versions in 
```
requirements.txt
``` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
